### PR TITLE
클라이언트 최상단 유저 정보 저장 로직 변경

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,6 +18,7 @@
         "axios": "^1.1.3",
         "eslint-config-airbnb": "^19.0.4",
         "react": "^18.2.0",
+        "react-cookie": "^4.1.1",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.4.3",
         "react-scripts": "5.0.1",
@@ -3760,6 +3761,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+    },
     "node_modules/@types/eslint": {
       "version": "8.4.10",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
@@ -3816,7 +3822,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
       "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
-      "dev": true,
       "dependencies": {
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
@@ -14149,6 +14154,19 @@
         "node": ">=14"
       }
     },
+    "node_modules/react-cookie": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.1.1.tgz",
+      "integrity": "sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.0.1",
+        "hoist-non-react-statics": "^3.0.0",
+        "universal-cookie": "^4.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -16143,6 +16161,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "dependencies": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
+      }
+    },
+    "node_modules/universal-cookie/node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/universalify": {
@@ -19750,6 +19785,11 @@
         "@types/node": "*"
       }
     },
+    "@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+    },
     "@types/eslint": {
       "version": "8.4.10",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
@@ -19806,7 +19846,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
       "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
-      "dev": true,
       "requires": {
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
@@ -27158,6 +27197,16 @@
         "whatwg-fetch": "^3.6.2"
       }
     },
+    "react-cookie": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.1.1.tgz",
+      "integrity": "sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.0.1",
+        "hoist-non-react-statics": "^3.0.0",
+        "universal-cookie": "^4.0.0"
+      }
+    },
     "react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -28615,6 +28664,22 @@
       "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
       "requires": {
         "crypto-random-string": "^2.0.0"
+      }
+    },
+    "universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "requires": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+          "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+        }
       }
     },
     "universalify": {

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,7 @@
     "axios": "^1.1.3",
     "eslint-config-airbnb": "^19.0.4",
     "react": "^18.2.0",
+    "react-cookie": "^4.1.1",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.3",
     "react-scripts": "5.0.1",

--- a/client/src/api/authApi.ts
+++ b/client/src/api/authApi.ts
@@ -1,0 +1,19 @@
+import axios from "axios";
+import API from "./routes";
+
+const authApi = {
+  login: async () => {
+    await axios.get(API.LOGIN, { withCredentials: true });
+  },
+  logout: async () => {
+    await axios.delete(API.LOGOUT);
+  },
+  getUserInfo: async () => {
+    console.log("getUserInfo");
+    const data = await axios.get(API.USER_INFO, { withCredentials: true });
+    console.log(data);
+    return data;
+  },
+};
+
+export default authApi;

--- a/client/src/api/formApi.ts
+++ b/client/src/api/formApi.ts
@@ -17,8 +17,8 @@ const formApi = {
 
     return data;
   },
-  getFormLists: async (userID: number, page: number, source: CancelTokenSource) => {
-    return axios(`${API.FORM}/${userID}/${page}`, { withCredentials: true, cancelToken: source.token });
+  getFormLists: async (page: number, source: CancelTokenSource) => {
+    return axios(`${API.FORM}/${page}`, { withCredentials: true, cancelToken: source.token });
   },
 };
 

--- a/client/src/api/routes.ts
+++ b/client/src/api/routes.ts
@@ -2,6 +2,9 @@ const BASE_URL = process.env.REACT_APP_SERVER_ORIGIN_URL;
 
 const API = {
   FORM: `${BASE_URL}/api/forms`,
+  LOGIN: `${BASE_URL}/api/users/redirect`,
+  LOGOUT: `${BASE_URL}/api/users/logout`,
+  USER_INFO: `${BASE_URL}/api/users`,
 };
 
 export default API;

--- a/client/src/contexts/authProvider.tsx
+++ b/client/src/contexts/authProvider.tsx
@@ -1,0 +1,33 @@
+import React, { createContext, useMemo, useState, useEffect } from "react";
+import { useCookies } from "react-cookie";
+import authApi from "api/authApi";
+
+interface AuthProps {
+  userID: string;
+  userName: string;
+}
+
+interface AuthContextProps {
+  auth?: AuthProps;
+  setAuth?: React.Dispatch<React.SetStateAction<AuthProps>>;
+}
+
+export const AuthContext = createContext<AuthContextProps>({});
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [auth, setAuth] = useState({ userID: "", userName: "" });
+  const [cookies] = useCookies();
+
+  useEffect(() => {
+    if (cookies.accessToken)
+      authApi.getUserInfo().then((userInfo) => {
+        if (!setAuth) return;
+
+        setAuth({ userID: userInfo.data.userID, userName: userInfo.data.userName });
+      });
+  }, [cookies]);
+
+  const AuthContextValue = useMemo(() => ({ auth, setAuth }), [auth, setAuth]);
+
+  return <AuthContext.Provider value={AuthContextValue}>{children}</AuthContext.Provider>;
+}

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -6,9 +6,8 @@ import Manage from "pages/Manage/Manage.component";
 import Create from "pages/Create/Create.component";
 import Main from "pages/Main/Main.component";
 import Login from "pages/Login/Login.component";
+import { AuthProvider } from "contexts/authProvider";
 import reportWebVitals from "./reportWebVitals";
-
-const AuthContext = createContext({ userID: "" });
 
 const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
 
@@ -34,9 +33,9 @@ const router = createBrowserRouter([
 root.render(
   <React.StrictMode>
     <GlobalStyle />
-    <AuthContext.Provider value={{ userID: "" }}>
+    <AuthProvider>
       <RouterProvider router={router} />
-    </AuthContext.Provider>
+    </AuthProvider>
   </React.StrictMode>
 );
 
@@ -44,5 +43,3 @@ root.render(
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
 reportWebVitals();
-
-export default AuthContext;

--- a/client/src/pages/Login/Login.component.tsx
+++ b/client/src/pages/Login/Login.component.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
+import authApi from "api/authApi";
 
-import AuthContext from "index";
+// import AuthContext from "index";
 
 import axios from "axios";
 import logo from "../../assets/Icon/plus.svg";
@@ -58,12 +59,13 @@ const HomeButton = styled.button`
 `;
 
 function Login() {
-  const userInfo = useContext(AuthContext);
+  // const userInfo = useContext(AuthContext);
   const navigate = useNavigate();
 
-  const handleClickOAuth: React.MouseEventHandler<HTMLButtonElement> = () => {
-    userInfo.userID = "testID-01";
+  const handleClickOAuth: React.MouseEventHandler<HTMLButtonElement> = async () => {
+    // userInfo.userID = "testID-01";
     window.location.href = `${process.env.REACT_APP_SERVER_ORIGIN_URL}/api/users/redirect`;
+    // await authApi.login();
   };
 
   const handleClickHome: React.MouseEventHandler<HTMLButtonElement> = () => {

--- a/client/src/pages/Main/Main.component.tsx
+++ b/client/src/pages/Main/Main.component.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
-
-import AuthContext from "index";
+import { AuthContext } from "contexts/authProvider";
 
 import logo from "../../assets/Icon/plus.svg";
 
@@ -52,11 +51,11 @@ const ServiceImage = styled.img`
 `;
 
 function Main() {
-  const userInfo = useContext(AuthContext);
+  const { auth } = useContext(AuthContext);
   const navigate = useNavigate();
 
   const handleClick: React.MouseEventHandler<HTMLButtonElement> = () => {
-    const path = userInfo.userID === "" ? "/login" : "/manage";
+    const path = auth?.userID ? "/manage" : "/login";
     navigate(path);
   };
 

--- a/client/src/pages/Manage/Manage.component.tsx
+++ b/client/src/pages/Manage/Manage.component.tsx
@@ -44,7 +44,7 @@ function Manage() {
     const source = axios.CancelToken.source();
 
     formApi
-      .getFormLists(10243, page, source)
+      .getFormLists(page, source)
       .then((response) => {
         setFetchedForms((prev) => [...prev, ...response.data.form]);
 

--- a/server/src/Common/Exceptions/Unauthorized.Exception.ts
+++ b/server/src/Common/Exceptions/Unauthorized.Exception.ts
@@ -1,0 +1,8 @@
+// 인증 실패에 대한 오류
+import HttpException from "./Http.Exception";
+
+export default class UnauthorizedException extends HttpException {
+  constructor(message = "인증 자격 증명이 유효하지 않습니다.") {
+    super(401, message);
+  }
+}


### PR DESCRIPTION
### 문제사항

1. 클라이언트 최상단에서 유저 정보를 갖고 싶어서 useEffect로 get - api/users로 받아온다. 현재 서버 로직상 accessToken이 없는 경우 무조건 login 페이지로 리다이렉트 시키기 때문에, main 페이지와 같은 로그인/비로그인 유저들이 같이 사용하는 페이지에서도 redirect가 시도되는 문제가 발생함

### 해결방안

1. document.cookie.accessToken의 유무를 확인한 후 서버에 요청을 보낸다
    - redirect 문제 발생 안함
    - 보안상 생각해봐도 shorterm인 accessToken 쿠키를 http-only 제약을 걸어둘 필요가 없음